### PR TITLE
Update Google Ads API version from v19 to v20

### DIFF
--- a/google_ads_server.py
+++ b/google_ads_server.py
@@ -32,7 +32,7 @@ mcp = FastMCP(
 
 # Constants and configuration
 SCOPES = ['https://www.googleapis.com/auth/adwords']
-API_VERSION = "v19"  # Google Ads API version
+API_VERSION = "v20"  # Google Ads API version
 
 # Load environment variables
 try:


### PR DESCRIPTION
## Summary
- Updates Google Ads API version from v19 to v20

## Issue
Fixes #16

## Details
Google Ads API v19 is now deprecated and blocked by Google's API. This causes all API calls to fail with the error:
```
Version v19 is deprecated. Requests to this version will be blocked.
```

This PR updates the `API_VERSION` constant to `v20` to restore functionality.

## Testing
After this change, API calls should work correctly with the Google Ads API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the Google Ads API_VERSION from v19 to v20 to restore requests now that v19 is blocked by Google. Fixes #16.

<sup>Written for commit b353a51b7ff807f4f33b0932740525514763611c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

