### PR TITLE
Update Google Ads API version from v19 to v23

### DIFF
--- a/google_ads_server.py
+++ b/google_ads_server.py
@@ -32,7 +32,7 @@ mcp = FastMCP(
 
 # Constants and configuration
 SCOPES = ['https://www.googleapis.com/auth/adwords']
-API_VERSION = "v19"  # Google Ads API version
+API_VERSION = "v23"  # Google Ads API version
 
 # Load environment variables
 try:


### PR DESCRIPTION
Google Ads API v19 was sunset on February 11, 2026, causing the MCP server to fail with authentication errors.
Updated API version from v19 to v23 (current stable version as of February 2026).

Testing:
- Verified v23 is available and stable
- Fixes the "API version deprecated" error

Closes #17

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated Google Ads API version from v19 to v23 to resolve authentication errors after v19 sunset and restore MCP server functionality.

<sup>Written for commit bb8b1a2b6bbd10dd9a0b2b99926d3ea1fe148bd5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

