### PR TITLE
Upgrade Google Ads API version from v19 to v24

### DIFF
--- a/google_ads_server.py
+++ b/google_ads_server.py
@@ -32,7 +32,7 @@ mcp = FastMCP(
 
 # Constants and configuration
 SCOPES = ['https://www.googleapis.com/auth/adwords']
-API_VERSION = "v19"  # Google Ads API version
+API_VERSION = "v24"  # Google Ads API version
 
 # Load environment variables
 try:


### PR DESCRIPTION
## Summary
- Bumps `API_VERSION` from `v19` to `v24` in `google_ads_server.py`\n- v19 was sunset and returning 404 errors on all API calls\n- v24 is the current supported version (released April 2026)\n\n## Test plan\n- [ ] Verify `list_accounts` returns accounts without 404\n- [ ] Verify GAQL queries execute successfully against v24 endpoints

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded Google Ads API from v19 to v24 by updating `API_VERSION` to the current supported version, restoring successful requests and stopping 404s after v19 sunset. This unblocks `list_accounts` and GAQL queries against v24 endpoints.

<sup>Written for commit c4a907fdf9d500b07554fc57468280ecee3ed1a8. Summary will update on new commits. <a href="https://cubic.dev/pr/cohnen/mcp-google-ads/pull/21?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

